### PR TITLE
Sync Claude Code status line config from runconfig

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,22 @@
     "defaultMode": "auto",
     "allow": [
       "mcp__atlassian__getJiraIssue"
+    ],
+    "deny": [
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~*)",
+      "Bash(rm -rf $HOME*)",
+      "Bash(sudo*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git push --force-with-lease*)",
+      "Bash(git reset --hard origin*)",
+      "Bash(git reset --hard upstream*)",
+      "Bash(git branch -D *)",
+      "Bash(curl*|*sh*)",
+      "Bash(curl*|*bash*)",
+      "Bash(wget*|*sh*)",
+      "Bash(wget*|*bash*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "model": "opus[1m]",
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline-command.sh"
+  },
+  "editorMode": "vim",
+  "verbose": true,
+  "skipAutoPermissionPrompt": true,
+  "permissions": {
+    "defaultMode": "auto",
+    "allow": [
+      "mcp__atlassian__getJiraIssue"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,32 +1,6 @@
 {
-  "model": "opus[1m]",
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
-  },
-  "editorMode": "vim",
-  "verbose": true,
-  "skipAutoPermissionPrompt": true,
-  "permissions": {
-    "defaultMode": "auto",
-    "allow": [
-      "mcp__atlassian__getJiraIssue"
-    ],
-    "deny": [
-      "Bash(rm -rf /*)",
-      "Bash(rm -rf ~*)",
-      "Bash(rm -rf $HOME*)",
-      "Bash(sudo*)",
-      "Bash(git push --force*)",
-      "Bash(git push -f*)",
-      "Bash(git push --force-with-lease*)",
-      "Bash(git reset --hard origin*)",
-      "Bash(git reset --hard upstream*)",
-      "Bash(git branch -D *)",
-      "Bash(curl*|*sh*)",
-      "Bash(curl*|*bash*)",
-      "Bash(wget*|*sh*)",
-      "Bash(wget*|*bash*)"
-    ]
   }
 }

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd')
+
+# Shorten the path like zsh %~ (replace $HOME with ~)
+home="$HOME"
+short_cwd="${cwd/#$home/~}"
+
+# Get git branch/status using git-prompt.sh if available
+git_info=""
+git_prompt_candidates=(
+  "/Library/Developer/CommandLineTools/usr/share/git-core/git-prompt.sh"
+  "/opt/homebrew/etc/bash_completion.d/git-prompt.sh"
+  "/usr/local/etc/bash_completion.d/git-prompt.sh"
+  "/usr/share/git-core/contrib/completion/git-prompt.sh"
+  "/usr/lib/git-core/git-sh-prompt"
+  "/etc/bash_completion.d/git-prompt"
+)
+git_prompt_sh=""
+for candidate in "${git_prompt_candidates[@]}"; do
+  if [ -f "$candidate" ]; then
+    git_prompt_sh="$candidate"
+    break
+  fi
+done
+if [ -n "$git_prompt_sh" ]; then
+  export GIT_PS1_SHOWDIRTYSTATE=1
+  export GIT_PS1_SHOWSTASHSTATE=1
+  export GIT_PS1_SHOWUNTRACKEDFILES=1
+  export GIT_PS1_SHOWUPSTREAM="auto"
+  # shellcheck source=/dev/null
+  source "$git_prompt_sh"
+  git_info=$(GIT_DIR="$cwd/.git" GIT_WORK_TREE="$cwd" __git_ps1 " (%s)" 2>/dev/null || true)
+  if [ -z "$git_info" ]; then
+    # fallback: walk up to find .git
+    check_dir="$cwd"
+    while [ "$check_dir" != "/" ]; do
+      if [ -d "$check_dir/.git" ] || [ -f "$check_dir/.git" ]; then
+        git_info=$(cd "$check_dir" && GIT_OPTIONAL_LOCKS=0 __git_ps1 " (%s)" 2>/dev/null || true)
+        break
+      fi
+      check_dir=$(dirname "$check_dir")
+    done
+  fi
+fi
+
+ctx_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+ctx_suffix=""
+if [ -n "$ctx_pct" ]; then
+  ctx_int=$(printf '%.0f' "$ctx_pct")
+  if [ "$ctx_int" -ge 90 ]; then
+    ctx_color='\033[31m'   # red
+  elif [ "$ctx_int" -ge 70 ]; then
+    ctx_color='\033[33m'   # yellow
+  else
+    ctx_color='\033[32m'   # green
+  fi
+  ctx_suffix=$(printf " ${ctx_color}[%d%%]\033[0m" "$ctx_int")
+fi
+
+model_suffix=""
+model_name=$(echo "$input" | jq -r '.model.display_name // .model.id // empty')
+[ -n "$model_name" ] && model_suffix=$(printf ' \033[36m[%s]\033[0m' "$model_name")
+
+cost=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+cost_suffix=""
+[ -n "$cost" ] && cost_suffix=$(printf ' $%.2f' "$cost")
+
+# Rate limit info from JSON input (five_hour window preferred, fall back to seven_day)
+rl_suffix=""
+rl_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+rl_resets=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+rl_label="5h"
+if [ -z "$rl_pct" ]; then
+  rl_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+  rl_resets=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+  rl_label="7d"
+fi
+if [ -n "$rl_pct" ]; then
+  rl_int=$(printf '%.0f' "$rl_pct")
+  if [ "$rl_int" -ge 80 ]; then
+    rl_color='\033[31m'   # red
+  elif [ "$rl_int" -ge 50 ]; then
+    rl_color='\033[33m'   # yellow
+  else
+    rl_color='\033[32m'   # green
+  fi
+  reset_str=""
+  if [ -n "$rl_resets" ] && [ "$rl_resets" != "null" ]; then
+    reset_str=$(date -r "$rl_resets" +"%H:%M" 2>/dev/null || date -d "@$rl_resets" +"%H:%M" 2>/dev/null || true)
+  fi
+  if [ -n "$reset_str" ]; then
+    rl_suffix=$(printf " ${rl_color}RL(${rl_label}):%d%% rst %s\033[0m" "$rl_int" "$reset_str")
+  else
+    rl_suffix=$(printf " ${rl_color}RL(${rl_label}):%d%%\033[0m" "$rl_int")
+  fi
+fi
+
+printf '\033[1m%s\033[0m%s%s%s%s%s' "$short_cwd" "$git_info" "$model_suffix" "$ctx_suffix" "$cost_suffix" "$rl_suffix"

--- a/initialize.sh
+++ b/initialize.sh
@@ -29,6 +29,11 @@ ln -si ./dotfiles/.zshrc .
 # or use your own credentials.
 ln -si ./dotfiles/.gitconfig .
 
+# Claude Code settings
+mkdir -p "$HOME/.claude"
+ln -si "$HOME/dotfiles/.claude/settings.json" "$HOME/.claude/settings.json"
+ln -si "$HOME/dotfiles/.claude/statusline-command.sh" "$HOME/.claude/statusline-command.sh"
+
 # mise for language version management
 mkdir -p "$HOME/.config/mise"
 cd "$HOME/.config/mise" || exit

--- a/initialize.sh
+++ b/initialize.sh
@@ -1,22 +1,28 @@
 #!/usr/bin/env bash
 
-# Install Apple Developer Tools (git, etc.)
-xcode-select --install
+is_macos() { [[ "$OSTYPE" == "darwin"* ]]; }
 
-# Change shell to default to bash
-# chsh -s "$(which bash)"
+if is_macos; then
+  # Install Apple Developer Tools (git, etc.)
+  xcode-select --install
 
-# Install [Homebrew](https://brew.sh/)
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Change shell to default to bash
+  # chsh -s "$(which bash)"
+
+  # Install [Homebrew](https://brew.sh/)
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
 
 # Clone this repository into your `$HOME` directory:
 cd "$HOME" || exit
 git clone https://github.com/dijonkitchen/dotfiles/
 
-# To install all the brew packages from the
-# [Brewfile](https://github.com/Homebrew/homebrew-bundle),
-cd "$HOME"/dotfiles || exit
-brew bundle --file=Brewfile
+if is_macos; then
+  # To install all the brew packages from the
+  # [Brewfile](https://github.com/Homebrew/homebrew-bundle),
+  cd "$HOME"/dotfiles || exit
+  brew bundle --file=Brewfile
+fi
 
 # In your `$HOME` directory,
 # symbolic link these files:
@@ -34,11 +40,13 @@ mkdir -p "$HOME/.claude"
 ln -si "$HOME/dotfiles/.claude/settings.json" "$HOME/.claude/settings.json"
 ln -si "$HOME/dotfiles/.claude/statusline-command.sh" "$HOME/.claude/statusline-command.sh"
 
-# mise for language version management
-mkdir -p "$HOME/.config/mise"
-cd "$HOME/.config/mise" || exit
-ln -si ../../dotfiles/config.toml .
-mise install
+# mise for language version management (skip if not installed)
+if command -v mise >/dev/null 2>&1; then
+  mkdir -p "$HOME/.config/mise"
+  cd "$HOME/.config/mise" || exit
+  ln -si ../../dotfiles/config.toml .
+  mise install
+fi
 
-source .bashrc
-source .zshrc
+source "$HOME/.bashrc"
+source "$HOME/.zshrc"


### PR DESCRIPTION
## Summary
- Mirror `.claude/settings.json` (statusLine only) and `.claude/statusline-command.sh` from the `runconfig` repo so local and Codespaces setups share one canonical Claude Code status line config.
- Wire `initialize.sh` to symlink them into `~/.claude/`, matching how the existing dotfiles are linked.
- `statusline-command.sh` git-prompt.sh lookup is portable (macOS + Linux paths) so the git segment works in both environments.
- Guard macOS-only steps (`xcode-select`, Homebrew install, `brew bundle`) in `initialize.sh` with an `is_macos` check so the script is safe to run on Linux/Codespaces. Also gate `mise install` on `mise` being on PATH.

## Test plan
- [ ] On macOS: run `initialize.sh`, confirm xcode/Homebrew/brew bundle steps run and `~/.claude/{settings.json,statusline-command.sh}` symlinks resolve.
- [ ] On Linux/Codespaces: run `initialize.sh`, confirm macOS-only steps are skipped and Claude symlinks still get created.
- [ ] In a Claude Code session: status line renders with git segment populated (verifies `git-prompt.sh` lookup works on the host).

---
_Generated by [Claude Code](https://claude.ai/code/session_01REs62mdEW98d5tojQbj5wG)_