### PR TITLE
refactor(agents): treat Claude Code on the web as non-interactive

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 # Claude Code SessionStart hook.
-# Installs deps that `make check` needs (bats, shellcheck, jq) so the
-# agent can run tests and linters from the start of the session. Only
-# runs on Claude Code on the web; local machines manage their own deps
-# via dotfiles bootstrap.
+# On Claude Code on the web (where the user's local ~/.claude/ is not
+# available), materialize this repo's .claude/ globals into ~/.claude/
+# via link-agents.sh, then install the deps that `make check` needs
+# (bats, shellcheck, jq) so the agent can run tests and linters from
+# the start of the session. Local machines manage both via bootstrap.
 set -euo pipefail
 
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Run the install in the background so the session can start while apt
-# works. 5 min cap matches the apt + index fetch worst case.
+# Run in the background so the session can start while apt works. 5 min
+# cap matches the apt + index fetch worst case.
 echo '{"async": true, "asyncTimeout": 300000}'
+
+# Symlink the dotfiles' .claude/ (statusline, CLAUDE.md, skills, the
+# settings.json with this very hook) into ~/.claude/ so they apply at
+# the user scope, not just the project scope. Idempotent.
+"$CLAUDE_PROJECT_DIR/link-agents.sh"
 
 # `make test-deps` runs apt-get update, which can fail on the web image
 # due to unrelated third-party PPAs. Install directly, restricting

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ SH_FILES := \
 	homebrew.sh \
 	python.sh \
 	ruby.sh \
-	.claude/statusline-command.sh
+	.claude/statusline-command.sh \
+	.claude/hooks/session-start.sh
 
 .PHONY: help test-deps lint test check
 

--- a/link-agents.sh
+++ b/link-agents.sh
@@ -9,11 +9,12 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$SCRIPT_DIR/.agent/skills"
 
-is_codespaces() { [[ "${CODESPACES:-}" == "true" ]] || [[ -d /workspaces/.codespaces ]]; }
+is_codespaces()   { [[ "${CODESPACES:-}" == "true" ]] || [[ -d /workspaces/.codespaces ]]; }
+is_claude_remote() { [[ "${CLAUDE_CODE_REMOTE:-}" == "true" ]]; }
 # `-n` (--no-dereference) keeps `ln` from following an existing symlink to a
 # directory and creating a nested symlink inside it on re-run. Both GNU and
 # BSD `ln` accept `-n`.
-if is_codespaces; then LN_OPTS="-sfn"; else LN_OPTS="-sin"; fi
+if is_codespaces || is_claude_remote; then LN_OPTS="-sfn"; else LN_OPTS="-sin"; fi
 
 link_skills_into() {
   local target_dir="$1"

--- a/tests/link-agents.bats
+++ b/tests/link-agents.bats
@@ -53,3 +53,20 @@ teardown() {
 
   [ "$first" = "$second" ]
 }
+
+@test "Claude Code on the web runs non-interactively (CLAUDE_CODE_REMOTE)" {
+  # Drop the Codespaces fingerprint set in setup() so the Claude Code web
+  # branch is the only thing keeping us out of interactive `ln -i` mode.
+  unset CODESPACES
+  export CLAUDE_CODE_REMOTE=true
+
+  # Pre-create a conflicting target. Interactive ln would block on stdin
+  # and hang the test; force mode overwrites without prompting.
+  mkdir -p "$HOME/.claude"
+  echo "stale" > "$HOME/.claude/CLAUDE.md"
+
+  run "$SANDBOX_REPO/link-agents.sh" </dev/null
+  [ "$status" -eq 0 ]
+  [ -L "$HOME/.claude/CLAUDE.md" ]
+  [ "$(readlink "$HOME/.claude/CLAUDE.md")" = "$SANDBOX_REPO/.claude/CLAUDE.md" ]
+}


### PR DESCRIPTION
link-agents.sh used `ln -i` (interactive) anywhere outside Codespaces,
which hangs when the SessionStart hook on Claude Code on the web invokes
it with no stdin. Add an `is_claude_remote` fingerprint (CLAUDE_CODE_REMOTE=true)
and force `-sfn` in that environment too, mirroring the Codespaces branch.