### PR TITLE
fix(path): expose ~/.local/bin for Claude Code native installer

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -22,3 +22,6 @@ source "$HOME/dotfiles/ruby.sh"
 source "$HOME/dotfiles/python.sh"
 
 export PATH="$HOME/Library/Application Support/JetBrains/Toolbox/scripts:$PATH"
+
+# Claude Code native installer drops its binary in ~/.local/bin
+export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
Move the export into settings.sh so both bash and zsh pick it up. The native Claude Code installer drops its binary as a symlink in ~/.local/bin (alongside pipx shims, mise, and openshell), but nothing in the dotfiles had ever put that directory on PATH.

## Changes proposed in this pull request

1. 

See commits for more detail.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
