### PR TITLE
feat(claude): add global AGENTS.md as canonical agent instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,9 +1,1 @@
-# Workflow
-
-- Conventional commits, atomic scope. One logical change per commit. Use
-  `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, etc. with optional
-  scopes (e.g., `refactor(skills):`).
-- TDD when there is testable code. Write a failing test, then make it
-  pass, then refactor. Skip when the change is purely config or a thin
-  wrapper with no real test surface — and say so explicitly.
-- Apply the latest best practices for agentic coding.
+../AGENTS.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,19 @@
 {
+  "permissions": {
+    "allow": [
+      "mcp__atlassian__getJiraIssue"
+    ],
+    "defaultMode": "auto"
+  },
+  "worktree": {
+    "baseRef": "head"
+  },
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
   },
+  "editorMode": "vim",
+  "model": "opus",
   "hooks": {
     "SessionStart": [
       {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Workflow
+
+- Conventional commits, atomic scope. One logical change per commit. Use
+  `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, etc. with optional
+  scopes (e.g., `refactor(skills):`).
+- TDD when there is testable code. Write a failing test, then make it
+  pass, then refactor. Skip when the change is purely config or a thin
+  wrapper with no real test surface — and say so explicitly.
+- Apply the latest best practices for agentic coding.


### PR DESCRIPTION
Promote workflow guidance (atomic conventional commits, TDD, latest agentic best practices) to a top-level AGENTS.md and point .claude/CLAUDE.md at it via symlink, since Claude Code reads CLAUDE.md rather than AGENTS.md. Merge the live ~/.claude settings (permissions, worktree, editorMode, model: opus) into the canonical .claude/settings.json so dotfiles is the source of truth again.